### PR TITLE
[TECHNICAL SUPPORT] AUI-842 .ie body { position:relative } causes wrong previewing

### DIFF
--- a/src/aui-skin-base/css/layout.css
+++ b/src/aui-skin-base/css/layout.css
@@ -326,7 +326,7 @@
 	overflow: hidden;
 }
 
-.ie body {
+.ie7 body {
 	position: relative;
 }
 


### PR DESCRIPTION
... in Liferay Portal with IE9

For more info see the thread below, please.
http://in.liferay.com/web/global.engineering/forums/-/message_boards/message/1250529
