### PR TITLE
Update fs-extra to 0.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "devDependencies": {
         "async": "0.2.9",
         "command": "0.0.4",
-        "fs-extra": "0.6.3",
+        "fs-extra": "0.6.4",
         "grunt": "0.4.1",
         "grunt-contrib-clean": "0.5.0",
         "grunt-contrib-compass": "0.5.0",


### PR DESCRIPTION
npm show a warning about homepage
https://github.com/jprichardson/node-fs-extra/issues/28

Should we update to the newest version instead?
