### PR TITLE
AUI-1839	 - missing space between table and Select button in user profile

### DIFF
--- a/src/aui-datatable/assets/aui-datatable-body-core.css
+++ b/src/aui-datatable/assets/aui-datatable-body-core.css
@@ -1,3 +1,3 @@
 .table {
-    margin-bottom: 0px;
+    margin-bottom: 20px;
 }


### PR DESCRIPTION
Hi Hugo,

1:this issue a AUI issue ,and it was caused by that the value of the "aui-datatable-body.css",and the "aui-datatable-body.css" is a generated file , it is generated referring to "src/aui-datatable/assets/aui-datatable-body-core.css".

2: I have checked that it works in ee-6.2.x,enough the "alloy-ui jar" is not the same,we still can see that the value of "margin-bottom" is 20px. so we set it to 20px.

David.