### PR TITLE
update require-dir so that it works with node 0.10.6 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jshint-stylish": "^1.0.0",
     "liferay-gulp-tasks": "^0.5.1",
     "open": "~0.0.5",
-    "require-dir": "~0.1.0",
+    "require-dir": "^0.3.2",
     "run-sequence": "^2.0.0",
     "shifter": "~0.5.0",
     "spawn-local-bin": "~0.1.4",


### PR DESCRIPTION
#### Intent
To upgrade `require-dir` so that it won't fail with Node 0.10.6 or higher. 

#### Solution
- Increased the version of `require-dir` to 0.3.2 that no longer use `require.extensions` which have been deprecated since Node 0.10.6.
- Tested against major Node versions with `nvm`.