### PR TITLE
AUI-3133 A.DatePicker can conflict when using both aui-datepicker and aui-datepicker-deprecated on the same AUI sandbox (like in portal)

### DIFF
--- a/src/aui-datepicker-deprecated/js/aui-datepicker-base-deprecated.js
+++ b/src/aui-datepicker-deprecated/js/aui-datepicker-base-deprecated.js
@@ -321,7 +321,7 @@ var DatePicker = A.Component.create({
     }
 });
 
-A.DatePicker = DatePicker;
+A.DatePickerDeprecated = DatePicker;
 
 /**
  * A base class for DatepickerManager:


### PR DESCRIPTION
Hey @jonmak08,

I noticed that, because we reuse the A sandbox in portal, when navigating with SPA, the last one of aui-datepicker or aui-datepicker-deprecated to be loaded will be the one defining what A.DatePicker refers to.

From my tests, I think this is causing https://issues.liferay.com/browse/LPS-72999