### PR TITLE
AUI-3165 Add domType to mobile buttons

### DIFF
--- a/src/aui-toolbar/js/aui-toolbar.js
+++ b/src/aui-toolbar/js/aui-toolbar.js
@@ -365,6 +365,8 @@ ToolbarRenderer.prototype = {
                     buttonInstance.get('boundingBox').setAttribute('title', value.title);
                 }
 
+                buttonInstance.get('boundingBox').setAttribute('type', type);
+
                 return buttonInstance.get('boundingBox');
             }
 


### PR DESCRIPTION
https://issues.liferay.com/browse/AUI-3165
https://issues.liferay.com/browse/LPS-92181

When a modal appears above a Form, any button click will trigger a submit in mobile. This is due to not setting `domType` to `button`. Adding the type to `button `or given type will resolve this issue.

If there are any questions or comments please let me know.
Thank you!