### PR TITLE
AUI-3180 Correct 'alert-dimissable' to 'alert-dismissible' to keep co…

### DIFF
--- a/src/aui-alert/js/aui-alert.js
+++ b/src/aui-alert/js/aui-alert.js
@@ -7,7 +7,7 @@
 var getClassName = A.getClassName,
     CSS_CLOSE = getClassName('close'),
     CSS_INFO = getClassName('alert', 'info'),
-    CSS_DISMISSABLE = getClassName('alert', 'dismissable');
+    CSS_DISMISSIBLE = getClassName('alert', 'dismissible');
 
 /**
  * A base class for Alert.
@@ -110,7 +110,7 @@ A.Alert = A.Base.create('alert', A.Widget, [
         var boundingBox = this.get('boundingBox'),
             closeableNode = this.get('closeableNode');
 
-        boundingBox.toggleClass(CSS_DISMISSABLE, val);
+        boundingBox.toggleClass(CSS_DISMISSIBLE, val);
 
         closeableNode.remove();
 


### PR DESCRIPTION
/cc @knchau 

Notes from Kim:

> https://issues.liferay.com/browse/AUI-3180
> 
> The issue is relatively straight-forward. QA requests to change html element `alert-dismissible` of error message because it is convenient for maintaining branch by automation testcase. 
> 
> My fix changes the spelling to existing class selector `alert-dismissible`.