### PR TITLE
AUI-3182 In Calendar's monthly view, when today's date is the first d…

### DIFF
--- a/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
+++ b/src/aui-scheduler/assets/aui-scheduler-view-table-core.css
@@ -171,6 +171,10 @@
     border-bottom-width: 0;
 }
 
+.scheduler-view-table-row:not(:last-child) .scheduler-view-table-colgrid-today {
+    border-left: 1px solid #009be6;
+}
+
 .scheduler-view-table-row:last-child .scheduler-view-table-colgrid-today {
     border-bottom-width: 1px;
 }


### PR DESCRIPTION
/cc @knchau 

Notes from Kim:
> https://issues.liferay.com/browse/AUI-3182
> 
> Left blue border of today's date is cut out when it is the first day of the week. 
> 
> The fix makes the left border above when it is the first day of the week and today's date.