### PR TITLE
AUI-3200 Fix tree is built without children nodes (aui-tree-view)

### DIFF
--- a/src/aui-tree/js/aui-tree-data.js
+++ b/src/aui-tree/js/aui-tree-data.js
@@ -784,7 +784,7 @@ A.mix(TreeData.prototype, {
 
         instance.childrenLength = v.length;
 
-        if (instance.childrenLength && !container) {
+        if (!container) {
             container = instance._createNodeContainer();
         }
 

--- a/src/aui-tree/js/aui-tree-node.js
+++ b/src/aui-tree/js/aui-tree-node.js
@@ -569,11 +569,7 @@ var TreeNode = A.Component.create({
 
             var nodeContainer = instance.get('container');
 
-            if (nodeContainer) {
-                if (!instance.get('expanded')) {
-                    nodeContainer.hide();
-                }
-
+            if (nodeContainer && instance.get('expanded')) {
                 boundingBox.append(nodeContainer);
             }
 


### PR DESCRIPTION
AUI-3200 Fix tree is built without children nodes (aui-tree-view) regression of AUI-3196 Prevent tree to create empty container <ul></ul> with no children, remove previous condition and add ul element only when is expanded (has children's).

/cc @jonmak08 Please review.
It is a regression of https://github.com/liferay/alloy-ui/pull/167 
 