### PR TITLE
AUI-3201 Fix tree is built without children nodes when not expanded false

### DIFF
--- a/src/aui-tree/js/aui-tree-node.js
+++ b/src/aui-tree/js/aui-tree-node.js
@@ -569,8 +569,13 @@ var TreeNode = A.Component.create({
 
             var nodeContainer = instance.get('container');
 
-            if (nodeContainer && instance.get('expanded')) {
-                boundingBox.append(nodeContainer);
+            if (nodeContainer) {
+                if (!instance.get('expanded')) {
+                    nodeContainer.hide();
+                }
+                if (this.childrenLength) {
+                    boundingBox.append(nodeContainer);
+                }
             }
 
             return boundingBox;


### PR DESCRIPTION
AUI-3201 Fix tree is built without children nodes when not expanded (aui-tree-view) regression of AUI-3200 Prevent tree to create empty container <ul></ul> with no children, remove previous condition and add ul element only when has children's (this.childrenLength greater than zero).

/cc @jonmak08 Please review.
It is a regression of https://github.com/liferay/alloy-ui/pull/168
 