### PR TITLE
AUI-3205 Fix tree is built without children nodes on Page Tree

### DIFF
--- a/src/aui-tree/js/aui-tree-node.js
+++ b/src/aui-tree/js/aui-tree-node.js
@@ -573,7 +573,7 @@ var TreeNode = A.Component.create({
                 if (!instance.get('expanded')) {
                     nodeContainer.hide();
                 }
-                if (this.childrenLength) {
+                if (instance.hasChildNodes()) {
                     boundingBox.append(nodeContainer);
                 }
             }


### PR DESCRIPTION
AUI-3205 Fix tree is built without children nodes use instance.hasChildNodes() instead
Fixes https://issues.liferay.com/browse/LPS-138270