### PR TITLE
AUI-3206 append container as we expand tree item

### DIFF
--- a/src/aui-tree/js/aui-tree-node.js
+++ b/src/aui-tree/js/aui-tree-node.js
@@ -716,6 +716,13 @@ var TreeNode = A.Component.create({
         expand: function() {
             var instance = this;
 
+            var boundingBox = instance.get('boundingBox');
+            var nodeContainer = instance.get('container');
+
+            if (nodeContainer && !boundingBox.contains(nodeContainer)) {
+                boundingBox.append(nodeContainer);
+            }
+
             instance.set('expanded', true);
         },
 


### PR DESCRIPTION
Hey,

[AUI-3206](https://issues.liferay.com/browse/AUI-3206),
[LPS-140686](https://issues.liferay.com/browse/LPS-140686) - LPS to commit the solution to liferay

The tree view was not able to expand if we loaded the items as collapsed after https://issues.liferay.com/browse/AUI-3205
Please review my change.

Thanks,

